### PR TITLE
Create Update set description should not be empty

### DIFF
--- a/Update set description should not be empty
+++ b/Update set description should not be empty
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unload unload_date="2021-10-09 20:01:31">
+<scan_table_check action="INSERT_OR_UPDATE">
+<active>true</active>
+<advanced>false</advanced>
+<attributes display_value=""/>
+<category>manageability</category>
+<conditions table="sys_update_set">descriptionISEMPTY^state!=ignore^EQ<item goto="false" or="false" field="description" endquery="false" value="" operator="ISEMPTY" newquery="false"/>
+<item goto="false" or="false" field="state" endquery="false" value="ignore" operator="!=" newquery="false"/>
+<item goto="false" or="false" field="" endquery="true" value="" operator="=" newquery="false"/>
+</conditions>
+<description>Update set description provides the release management team to better understand what's getting pushed</description>
+<documentation_url/>
+<finding_type>scan_finding</finding_type>
+<name>Update Set Description Empty</name>
+<priority>4</priority>
+<resolution_details>The description should not be empty</resolution_details>
+<run_condition/>
+<score_max>100</score_max>
+<score_min>0</score_min>
+<score_scale>1</score_scale>
+<script><![CDATA[(function (engine) {
+
+    // Add your code here
+
+})(engine);]]></script>
+<short_description>Update set descriptions should not be left empty </short_description>
+<sys_class_name>scan_table_check</sys_class_name>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2021-10-09 16:31:59</sys_created_on>
+<sys_id>003db2922f43301002f0ffecf699b617</sys_id>
+<sys_mod_count>1</sys_mod_count>
+<sys_name>Update Set Description Empty</sys_name>
+<sys_package display_value="Global" source="global">global</sys_package>
+<sys_policy/>
+<sys_scope display_value="Global">global</sys_scope>
+<sys_update_name>scan_table_check_003db2922f43301002f0ffecf699b617</sys_update_name>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2021-10-09 20:01:21</sys_updated_on>
+<table>sys_update_set</table>
+<use_manifest>false</use_manifest>
+</scan_table_check>
+</unload>


### PR DESCRIPTION
Validate the description of the update sets created is not empty as it provides the release management team to better understand what's getting pushed