### PR TITLE
check for lockedout user set as RunAs for ScheduledJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Monitor users with role `admin` (not locked out) that are not logged for longer 
 After deactivation of Groups there can be still some users.
 Group offer membership but also can provide some roles that after deactivation should be considered as no longer needed.
 
+### Scheduled Job with RunAs set as Locked Out user
+Detecting no longer active user with flag Locked Out set to true that is set as a RunAs for Scheduled Job
 
 ## Category: User Experience
 

--- a/scan_script_only_check_718e43b42f2330100b40bea62799b67f.xml
+++ b/scan_script_only_check_718e43b42f2330100b40bea62799b67f.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unload unload_date="2021-10-29 22:24:36">
+<scan_script_only_check action="INSERT_OR_UPDATE">
+<active>true</active>
+<attributes display_value="Locked out user for Scheduled Job">125fc7742f2330100b40bea62799b6fb</attributes>
+<category>security</category>
+<description/>
+<documentation_url/>
+<name>Locked out user for Scheduled Job</name>
+<priority>2</priority>
+<resolution_details/>
+<script><![CDATA[(function(finding) {
+
+    var grSysauto = new GlideRecord('sysauto');
+    grSysauto.addEncodedQuery("run_as.locked_out=true");
+    grSysauto.query();
+    while (grSysauto.next()) {
+        finding.setCurrentSource(grSysauto);
+        finding.increment();
+    }
+
+})(finding);
+]]></script>
+<short_description>Locked out user detection in Run as for Scheduled Jobs</short_description>
+<sys_class_name>scan_script_only_check</sys_class_name>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2021-10-29 22:13:02</sys_created_on>
+<sys_id>718e43b42f2330100b40bea62799b67f</sys_id>
+<sys_mod_count>1</sys_mod_count>
+<sys_name>Locked out user for Scheduled Job</sys_name>
+<sys_package display_value="Global" source="global">global</sys_package>
+<sys_policy/>
+<sys_scope display_value="Global">global</sys_scope>
+<sys_update_name>scan_script_only_check_718e43b42f2330100b40bea62799b67f</sys_update_name>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2021-10-29 22:24:25</sys_updated_on>
+</scan_script_only_check>
+</unload>


### PR DESCRIPTION
Next example where Table Check is not able to list records with simple condition (table: sysauto_script, condition: run_as.locked_out=true)
Decided to use Script Only Check to detect Locked Out user set as RunAs for Scheduled Job