### PR TITLE
Update getReference cherk to run only on client scripts

### DIFF
--- a/ca8467c41b9abc10ce0f62c3b24bcbaa/update/scan_linter_check_266f89b32f2d7110d53f821df699b626.xml
+++ b/ca8467c41b9abc10ce0f62c3b24bcbaa/update/scan_linter_check_266f89b32f2d7110d53f821df699b626.xml
@@ -13,14 +13,17 @@
         <score_min>0</score_min>
         <score_scale>1</score_scale>
         <script><![CDATA[(function(engine) {
-
-    // Perform Linter Check
-    engine.rootNode.visit(function(node) {
-        if (node.getTypeName() === "NAME" && node.getNameIdentifier() === "getReference" && node.getParent().getTypeName() === "GETPROP") {
-            // Create scan finding
-            engine.finding.incrementWithNode(node);
-        }
-    });
+    // This check only applicable to Client Scripts and Catalog Client Scripts
+    if (current.getRecordClassName().toString() == 'sys_script_client'
+		|| current.getRecordClassName().toString() == 'catalog_script_client') {
+        engine.rootNode.visit(function(node) {
+            if (node.getTypeName() === "NAME" &&
+                node.getNameIdentifier() === "getReference" &&
+                node.getParent().getTypeName() === "GETPROP") {
+                engine.finding.incrementWithNode(node);
+            }
+        });
+    }
 
 })(engine);]]></script>
         <short_description>Avoid using getReference()</short_description>


### PR DESCRIPTION
Limit the scan to only applicable tables in order to improve the performance of the scan