### PR TITLE
Empty recipients for active notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ Finds integration users that have assigned admin role - there are two types:
 Already completed Update Set shouldn't be set back to In Pogress
 There is risk that even for a moment completed update set were retrieved to higher environment and won't be retrieved once again after more modifications are done on lower environment
 
+### Active notifications with empty any recipients class
+For notification records there are condition to be met, active flag - they indicates that some notificaton should reach recipients
+It happens from time to time that after development or conifguration all the three classes of recpients can be empty:
+- Users | recipient_users
+- Users/Groups in fields | recipient_fields
+- Groups | recipient_groups
+It can cause except issue with manageability also some performance impact - to verify active notification against some conditions and at the end no notification produced
+
 ## Category: Upgradability
 
 ### Call GlideRecord using new

--- a/ca8467c41b9abc10ce0f62c3b24bcbaa/update/scan_table_check_dcc8978c2f4a7110b0b62d5df699b603.xml
+++ b/ca8467c41b9abc10ce0f62c3b24bcbaa/update/scan_table_check_dcc8978c2f4a7110b0b62d5df699b603.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<unload unload_date="2023-10-18 10:10:47">
+<scan_table_check action="INSERT_OR_UPDATE">
+<active>true</active>
+<advanced>false</advanced>
+<category>manageability</category>
+<conditions table="sysevent_email_action">active=true^recipient_usersISEMPTY^recipient_fieldsISEMPTY^recipient_groupsISEMPTY^EQ<item goto="false" or="false" field="active" endquery="false" value="true" operator="=" newquery="false"/>
+<item goto="false" or="false" field="recipient_users" endquery="false" value="" operator="ISEMPTY" newquery="false"/>
+<item goto="false" or="false" field="recipient_fields" endquery="false" value="" operator="ISEMPTY" newquery="false"/>
+<item goto="false" or="false" field="recipient_groups" endquery="false" value="" operator="ISEMPTY" newquery="false"/>
+<item goto="false" or="false" field="" endquery="true" value="" operator="=" newquery="false"/>
+</conditions>
+<description/>
+<documentation_url/>
+<finding_type>scan_finding</finding_type>
+<name>Active notification without any recipients</name>
+<priority>3</priority>
+<resolution_details/>
+<run_condition/>
+<score_max>100</score_max>
+<score_min>0</score_min>
+<score_scale>1</score_scale>
+<script/>
+<short_description>Neither of recipients class is specified</short_description>
+<sys_class_name>scan_table_check</sys_class_name>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2023-10-18 10:09:08</sys_created_on>
+<sys_id>dcc8978c2f4a7110b0b62d5df699b603</sys_id>
+<sys_mod_count>1</sys_mod_count>
+<sys_name>Active notification without any recipients</sys_name>
+<sys_package display_value="Global" source="global">global</sys_package>
+<sys_policy/>
+<sys_scope display_value="Global">global</sys_scope>
+<sys_update_name>scan_table_check_dcc8978c2f4a7110b0b62d5df699b603</sys_update_name>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2023-10-18 10:09:26</sys_updated_on>
+<table>sysevent_email_action</table>
+<use_manifest>false</use_manifest>
+</scan_table_check>
+</unload>


### PR DESCRIPTION
**Active notifications with empty any recipients class**

For notification records there are condition to be met, active flag - they indicates that some notificaton should reach recipients
It happens from time to time that after development or conifguration all the three classes of recpients can be empty:
- Users | recipient_users
- Users/Groups in fields | recipient_fields
- Groups | recipient_groups
It can cause except issue with manageability also some performance impact - to verify active notification against some conditions and at the end no notification produced